### PR TITLE
Server commands and systemd service

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -5,10 +5,14 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"text/template"
 	"time"
 
 	"atelier-go/internal/api"
 	"atelier-go/internal/auth"
+	"atelier-go/internal/system"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -51,6 +55,162 @@ var serverCmd = &cobra.Command{
 
 		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			log.Fatalf("Server failed: %v", err)
+		}
+	},
+}
+
+var serverStartCmd = &cobra.Command{
+	Use:   "start",
+	Short: "Start the server in the background",
+	Run: func(cmd *cobra.Command, args []string) {
+		// Check if already running
+		pid, err := system.ReadPIDFile()
+		if err == nil {
+			if system.IsProcessRunning(pid) {
+				fmt.Printf("Server is already running (PID: %d)\n", pid)
+				return
+			}
+			// PID file exists but process is dead, clean it up
+			system.RemovePIDFile()
+		}
+
+		// Find the executable
+		exe, err := os.Executable()
+		if err != nil {
+			log.Fatalf("Failed to determine executable path: %v", err)
+		}
+
+		// Start the process detached
+		startCmd := exec.Command(exe, "server")
+		// Detach logic usually involves redirecting std I/O and handling process groups,
+		// but simply starting it via exec without waiting and letting it write its PID is often enough for simple use cases.
+		// However, to truly background it and have it survive the parent shell exit, we might want to setsid.
+		// For simplicity in this Go implementation, we'll start it and just not Wait().
+		// Since the parent (this CLI command) exits immediately, the child effectively becomes a daemon.
+
+		// Redirect output to log file? Or just /dev/null for now?
+		// A proper background service should probably log somewhere.
+		// For now, let's inherit environment but detach I/O so it doesn't hang the terminal.
+		startCmd.Stdout = nil
+		startCmd.Stderr = nil
+		startCmd.Stdin = nil
+
+		if err := startCmd.Start(); err != nil {
+			log.Fatalf("Failed to start server: %v", err)
+		}
+
+		// Write PID file
+		if err := system.WritePIDFile(startCmd.Process.Pid); err != nil {
+			// Try to kill the process if we can't write the PID file
+			startCmd.Process.Kill()
+			log.Fatalf("Failed to write PID file: %v", err)
+		}
+
+		fmt.Printf("Server started in background (PID: %d)\n", startCmd.Process.Pid)
+	},
+}
+
+var serverStopCmd = &cobra.Command{
+	Use:   "stop",
+	Short: "Stop the background server",
+	Run: func(cmd *cobra.Command, args []string) {
+		pid, err := system.ReadPIDFile()
+		if err != nil {
+			fmt.Println("No running server found (PID file missing).")
+			return
+		}
+
+		proc, err := os.FindProcess(pid)
+		if err != nil {
+			fmt.Println("Could not find process.")
+			// Clean up stale file
+			system.RemovePIDFile()
+			return
+		}
+
+		if err := proc.Kill(); err != nil {
+			fmt.Printf("Failed to stop server: %v\n", err)
+			return
+		}
+
+		system.RemovePIDFile()
+		fmt.Println("Server stopped.")
+	},
+}
+
+var serverInstallCmd = &cobra.Command{
+	Use:   "install",
+	Short: "Install the server as a systemd user service",
+	Run: func(cmd *cobra.Command, args []string) {
+		exe, err := os.Executable()
+		if err != nil {
+			log.Fatalf("Failed to determine executable path: %v", err)
+		}
+
+		// Template for systemd service
+		const serviceTmpl = `[Unit]
+Description=Atelier Go Server
+Documentation=https://github.com/shell-pool/atelier-go
+After=network.target
+
+[Service]
+Type=simple
+ExecStart={{.ExecPath}} server
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=default.target
+`
+		data := struct {
+			ExecPath string
+		}{
+			ExecPath: exe,
+		}
+
+		home, err := os.UserHomeDir()
+		if err != nil {
+			log.Fatalf("Failed to get user home directory: %v", err)
+		}
+
+		// Ensure ~/.local/share/systemd/user exists
+		serviceDir := filepath.Join(home, ".local", "share", "systemd", "user")
+		if err := os.MkdirAll(serviceDir, 0755); err != nil {
+			log.Fatalf("Failed to create systemd directory: %v", err)
+		}
+
+		servicePath := filepath.Join(serviceDir, "atelier-go.service")
+
+		// Generate file
+		f, err := os.Create(servicePath)
+		if err != nil {
+			log.Fatalf("Failed to create service file: %v", err)
+		}
+		defer f.Close()
+
+		tmpl, err := template.New("service").Parse(serviceTmpl)
+		if err != nil {
+			log.Fatalf("Failed to parse template: %v", err)
+		}
+
+		if err := tmpl.Execute(f, data); err != nil {
+			log.Fatalf("Failed to write service file: %v", err)
+		}
+
+		fmt.Printf("Service file created at %s\n", servicePath)
+
+		// Enable and start
+		// systemctl --user daemon-reload
+		// systemctl --user enable --now atelier-go
+
+		if err := exec.Command("systemctl", "--user", "daemon-reload").Run(); err != nil {
+			fmt.Printf("Warning: Failed to reload systemd daemon: %v\n", err)
+		} else {
+			if err := exec.Command("systemctl", "--user", "enable", "--now", "atelier-go").Run(); err != nil {
+				fmt.Printf("Warning: Failed to enable/start service: %v\n", err)
+			} else {
+				fmt.Println("Service installed and started successfully!")
+			}
 		}
 	},
 }
@@ -104,4 +264,7 @@ var serverStatusCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(serverCmd)
 	serverCmd.AddCommand(serverStatusCmd)
+	serverCmd.AddCommand(serverStartCmd)
+	serverCmd.AddCommand(serverStopCmd)
+	serverCmd.AddCommand(serverInstallCmd)
 }

--- a/internal/system/daemon.go
+++ b/internal/system/daemon.go
@@ -1,0 +1,56 @@
+package system
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"syscall"
+)
+
+// GetPIDFilePath returns the path to the PID file.
+// It prefers XDG_RUNTIME_DIR, but falls back to a local state directory.
+func GetPIDFilePath() string {
+	runtimeDir := os.Getenv("XDG_RUNTIME_DIR")
+	if runtimeDir != "" {
+		return filepath.Join(runtimeDir, "atelier-go.pid")
+	}
+
+	// Fallback
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".local", "state", "atelier-go", "atelier-go.pid")
+}
+
+// WritePIDFile writes the current process ID to the PID file.
+func WritePIDFile(pid int) error {
+	path := GetPIDFilePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(strconv.Itoa(pid)), 0600)
+}
+
+// ReadPIDFile reads the PID from the PID file.
+func ReadPIDFile() (int, error) {
+	path := GetPIDFilePath()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.Atoi(string(data))
+}
+
+// RemovePIDFile removes the PID file.
+func RemovePIDFile() error {
+	return os.Remove(GetPIDFilePath())
+}
+
+// IsProcessRunning checks if a process with the given PID is running.
+func IsProcessRunning(pid int) bool {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	// Sending signal 0 is a way to check if the process exists without killing it.
+	err = process.Signal(syscall.Signal(0))
+	return err == nil
+}


### PR DESCRIPTION
This pull request adds background process management and systemd integration for the server, making it possible to start, stop, and install the server as a user service. The main changes include new CLI commands for managing the server lifecycle and a new internal package for PID file and process management.

### Server management commands

* Added `start`, `stop`, and `install` subcommands to the `server` CLI, allowing users to run the server in the background, stop it, and install it as a systemd user service. These commands handle process creation, termination, and service file generation.
* Registered the new subcommands with the server command in the CLI initialization logic.

### Background process and PID management

* Introduced the new `internal/system/daemon.go` package, providing utilities for PID file creation, reading, removal, and process existence checks. This ensures reliable tracking and management of the server's background process.
* Updated imports in `cmd/server.go` to include necessary packages for process management and templating.