### PR TITLE
Server token config and management

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -29,8 +29,30 @@ var clientCmd = &cobra.Command{
 	},
 }
 
+var clientLoginCmd = &cobra.Command{
+	Use:   "login [token]",
+	Short: "Save the authentication token",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		token := args[0]
+		tokenPath, err := auth.GetDefaultTokenPath()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error getting token path: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := auth.SaveToken(tokenPath, token); err != nil {
+			fmt.Fprintf(os.Stderr, "Error saving token: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Token saved successfully to %s\n", tokenPath)
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(clientCmd)
+	clientCmd.AddCommand(clientLoginCmd)
 }
 
 func runClient() {
@@ -41,7 +63,11 @@ func runClient() {
 	port := viper.GetInt("port")
 
 	// 1. Load Token
-	tokenPath := os.ExpandEnv("$HOME/.config/atelier/token")
+	tokenPath, err := auth.GetDefaultTokenPath()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error getting token path: %v\n", err)
+		os.Exit(1)
+	}
 	token, err := auth.LoadOrCreateToken(tokenPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error loading token: %v\n", err)

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -11,10 +11,30 @@ import (
 
 var currentToken string
 
+// GetDefaultTokenPath returns the XDG-compliant path for the token file
+func GetDefaultTokenPath() (string, error) {
+	dataHome := os.Getenv("XDG_DATA_HOME")
+	if dataHome == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		dataHome = filepath.Join(home, ".local", "share")
+	}
+	return filepath.Join(dataHome, "atelier-go", "token"), nil
+}
+
 // LoadOrCreateToken ensures a token exists at the given path.
-// If it doesn't, it generates one and saves it.
+// If ATELIER_TOKEN env var is set, it uses that.
+// If it doesn't, it generates one and saves it to path.
 // Returns the token string.
 func LoadOrCreateToken(path string) (string, error) {
+	// Check environment variable first
+	if envToken := os.Getenv("ATELIER_TOKEN"); envToken != "" {
+		currentToken = envToken
+		return envToken, nil
+	}
+
 	// Expand ~ if present (simple handling for now, assuming HOME env var is set)
 	if strings.HasPrefix(path, "~") {
 		home, err := os.UserHomeDir()
@@ -56,6 +76,31 @@ func LoadOrCreateToken(path string) (string, error) {
 
 	currentToken = token
 	return token, nil
+}
+
+// SaveToken writes the given token to the specified path, creating directories if needed.
+func SaveToken(path, token string) error {
+	// Expand ~ if present
+	if strings.HasPrefix(path, "~") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("failed to get user home dir: %w", err)
+		}
+		path = filepath.Join(home, path[1:])
+	}
+
+	// Ensure directory exists
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+
+	// Write to file
+	if err := os.WriteFile(path, []byte(token), 0600); err != nil {
+		return fmt.Errorf("failed to write token file: %w", err)
+	}
+
+	return nil
 }
 
 // GetCurrentToken returns the currently loaded token


### PR DESCRIPTION
This pull request introduces several improvements to authentication token management for both the server and client commands, with a focus on consistency, usability, and compliance with XDG directory standards. The most important changes include adding commands to manage tokens, refactoring token path handling to use a standardized function, and improving user feedback during server startup.

**Authentication Token Management Improvements**

* Added a new `client login [token]` command to allow users to save their authentication token from the CLI. (`cmd/client.go`)
* Added a new `server token` command to print the current authentication token. (`cmd/server.go`)
* Refactored token path handling across client and server commands to use the new `auth.GetDefaultTokenPath()` function, ensuring XDG compliance and reducing hardcoded paths. (`cmd/client.go`, `cmd/server.go`, `internal/auth/token.go`) [[1]](diffhunk://#diff-77cc8dd5b2fc01f2cbc5f714d0ae7ac6cf20bf5dc4eba6733bd3edbc5eefb7d9L44-R70) [[2]](diffhunk://#diff-ee2560d627cd77f1563972217a33ac39a4bf56fbf30d7f560fbb4199b9f70197L33-R55) [[3]](diffhunk://#diff-ee2560d627cd77f1563972217a33ac39a4bf56fbf30d7f560fbb4199b9f70197L229-R282) [[4]](diffhunk://#diff-0d305fe5f3bcae84bf3f15d68bb8e369ac708e0602377dda2ed14894a5a88f4dR14-R37)

**User Experience Enhancements**

* Added a startup banner to the server output that displays the address, token, and instructions for connecting the client, improving onboarding and clarity. (`cmd/server.go`) [[1]](diffhunk://#diff-ee2560d627cd77f1563972217a33ac39a4bf56fbf30d7f560fbb4199b9f70197R21-R33) [[2]](diffhunk://#diff-ee2560d627cd77f1563972217a33ac39a4bf56fbf30d7f560fbb4199b9f70197L33-R55) [[3]](diffhunk://#diff-ee2560d627cd77f1563972217a33ac39a4bf56fbf30d7f560fbb4199b9f70197R125-R140)

**Internal API Improvements**

* Added `auth.SaveToken()` to allow saving tokens to disk, and updated `auth.LoadOrCreateToken()` to prefer the `ATELIER_TOKEN` environment variable for greater flexibility. (`internal/auth/token.go`) [[1]](diffhunk://#diff-0d305fe5f3bcae84bf3f15d68bb8e369ac708e0602377dda2ed14894a5a88f4dR81-R105) [[2]](diffhunk://#diff-0d305fe5f3bcae84bf3f15d68bb8e369ac708e0602377dda2ed14894a5a88f4dR14-R37)