### PR TITLE
Location filters

### DIFF
--- a/internal/system/filesystem.go
+++ b/internal/system/filesystem.go
@@ -1,0 +1,39 @@
+package system
+
+import (
+	"bufio"
+	"bytes"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// GetAllEntries returns a list of all directories from the home directory using fd.
+// It excludes .git and node_modules.
+func GetAllEntries() ([]string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return []string{}, err
+	}
+
+	// fd --type d --base-directory $HOME --hidden --exclude .git --exclude node_modules
+	cmd := exec.Command("fd", "--type", "d", "--base-directory", home, "--hidden", "--exclude", ".git", "--exclude", "node_modules")
+	output, err := cmd.Output()
+	if err != nil {
+		// If fd fails or is not found, we return an empty list.
+		// In a production app we might want to distinguish between "not found" and "error",
+		// but per instructions we assume fd is required/available or we fail gracefully.
+		return []string{}, nil
+	}
+
+	var paths []string
+	scanner := bufio.NewScanner(bytes.NewReader(output))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line != "" {
+			paths = append(paths, line)
+		}
+	}
+
+	return paths, nil
+}


### PR DESCRIPTION
This pull request introduces new filtering options for the client command, allowing users to select which directories and sessions are displayed. It adds support for showing all directories in the home folder (using `fd`), only open sessions, or the default frequent directories (using `zoxide`). The backend API and client command are both updated to support these new filters.

**Client command improvements:**

* Added `--all` and `--sessions` flags to the `client` command, allowing users to select between showing all directories, only open sessions, or frequent directories. The command now passes a `filter` value to the backend API. [[1]](diffhunk://#diff-77cc8dd5b2fc01f2cbc5f714d0ae7ac6cf20bf5dc4eba6733bd3edbc5eefb7d9L28-R37) [[2]](diffhunk://#diff-77cc8dd5b2fc01f2cbc5f714d0ae7ac6cf20bf5dc4eba6733bd3edbc5eefb7d9R63-R69)

**Backend API enhancements:**

* Updated the `LocationsHandler` in `internal/api/locations.go` to accept a `filter` query parameter and dynamically select which tasks to run (sessions, frequent directories, or all directories). The handler now chooses between using `zoxide` or `fd` for directory listing based on the filter.

**Filesystem integration:**

* Added a new function `GetAllEntries` in `internal/system/filesystem.go` to list all directories in the user's home folder using the `fd` command, excluding `.git` and `node_modules`. This function is used when the "all" filter is selected.

**Minor improvements:**

* Updated the client to include the `filter` parameter in the API request URL to support the new filtering behavior.
* Minor formatting change in session creation for better readability.