### PR TITLE
Manage actions in config

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -66,6 +66,9 @@ var serverCmd = &cobra.Command{
 		// Locations Endpoint (Protected)
 		mux.Handle("/api/locations", auth.RequireToken(http.HandlerFunc(api.LocationsHandler)))
 
+		// Actions Endpoint (Protected)
+		mux.Handle("/api/actions", auth.RequireToken(http.HandlerFunc(api.ActionsHandler)))
+
 		server := &http.Server{
 			Addr:    addr,
 			Handler: mux,

--- a/internal/api/actions.go
+++ b/internal/api/actions.go
@@ -1,0 +1,53 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/spf13/viper"
+)
+
+type Action struct {
+	Name    string `json:"name" mapstructure:"name"`
+	Command string `json:"command" mapstructure:"command"`
+}
+
+type ActionsResponse struct {
+	Actions []Action `json:"actions"`
+}
+
+func ActionsHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var actions []Action
+	if err := viper.UnmarshalKey("actions", &actions); err != nil {
+		// If unmarshal fails, we start with an empty list
+		actions = []Action{}
+	}
+
+	// Ensure default shell action exists
+	hasShell := false
+	for _, a := range actions {
+		if a.Name == "shell" {
+			hasShell = true
+			break
+		}
+	}
+
+	if !hasShell {
+		actions = append(actions, Action{
+			Name:    "shell",
+			Command: "$SHELL -l",
+		})
+	}
+
+	response := ActionsResponse{
+		Actions: actions,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(response)
+}


### PR DESCRIPTION
This pull request introduces a new server-side API endpoint for fetching available actions, and updates the client to dynamically retrieve and select actions from the server instead of relying on hardcoded values. The changes improve extensibility and maintainability by centralizing action definitions and allowing for custom actions to be configured server-side.

**API and server enhancements:**

* Added a new `/api/actions` endpoint to the server, protected by authentication, which returns a list of available actions as defined in the server configuration. If no actions are defined, a default "shell" action is always included. (`internal/api/actions.go`, `cmd/server.go`) [[1]](diffhunk://#diff-82929ca62d7ae38166ece48af0319be7abd9dfc0e979f102e2a935eec5322492R1-R53) [[2]](diffhunk://#diff-ee2560d627cd77f1563972217a33ac39a4bf56fbf30d7f560fbb4199b9f70197R69-R71)

**Client-side improvements:**

* Updated the client to fetch available actions from the new API endpoint before presenting the action selection menu, with a fallback to the default "shell" action if the request fails. (`cmd/client.go`) [[1]](diffhunk://#diff-77cc8dd5b2fc01f2cbc5f714d0ae7ac6cf20bf5dc4eba6733bd3edbc5eefb7d9L129-R144) [[2]](diffhunk://#diff-77cc8dd5b2fc01f2cbc5f714d0ae7ac6cf20bf5dc4eba6733bd3edbc5eefb7d9R177-R201)
* Refactored the action selection logic to use the server-provided actions, and return the full `Action` object rather than just the action name. (`cmd/client.go`)
* Updated session creation to use the command associated with the selected action, improving flexibility for custom actions. (`cmd/client.go`)

**Minor cleanup:**

* Removed redundant comments and simplified error handling in SSH execution. (`cmd/client.go`)

Closes #8 