### PR TITLE
Removed login shell wrapper

### DIFF
--- a/internal/shell/builder.go
+++ b/internal/shell/builder.go
@@ -70,14 +70,13 @@ func BuildStartArgs(host, path string, info SessionInfo, actionCmd string) (stri
 	}
 
 	// 2. Build the inner shell command
-	// e.g. $SHELL -l -i -c 'command'
-	var finalCmd string
+	// e.g. $SHELL -c 'command'
+	// We no longer force -l -i; we rely on the action command to define its environment.
+	// However, we still wrap it in a shell -c to handle parsing/arguments correctly.
 	if actionCmd == "" {
-		finalCmd = fmt.Sprintf("%s -l -i", shell)
-	} else {
-		// Quote the action command for the -c flag
-		finalCmd = fmt.Sprintf("%s -l -i -c %s", shell, Quote(actionCmd))
+		actionCmd = shell
 	}
+	finalCmd := fmt.Sprintf("%s -c %s", shell, Quote(actionCmd))
 
 	// 3. Build the shpool command
 	if system.IsLocal(host) {


### PR DESCRIPTION
This pull request updates the way shell commands are constructed in the `BuildStartArgs` function. The main change is that the code no longer forces the use of the `-l -i` flags when launching a shell; instead, it relies on the action command to define its own environment. The shell command is still wrapped with `-c` to ensure proper parsing and argument handling.

Shell command construction changes:

* Removed forced use of `-l -i` flags when launching the shell in `BuildStartArgs`, relying on the action command to define its environment. The shell command is now always wrapped with `-c` for consistent argument parsing. (`internal/shell/builder.go`)