### PR TITLE
Simplify window titles

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -104,15 +104,15 @@ func (c *Client) Attach(sessionName string) error {
 
 // Start creates and attaches to a new session.
 func (c *Client) Start(path, name string, action api.Action, isProject bool) error {
-	// Prepare session info (ID and Title)
+	// Prepare session info (ID)
 	info := shell.PrepareSessionInfo(path, name, action.Name, isProject)
 
 	// Build the command arguments
 	bin, args := shell.BuildStartArgs(c.Host, path, info, action.Command)
 
 	// Update local title if running locally
-	if system.IsLocal(c.Host) && info.Title != "" {
-		fmt.Printf("\033]2;%s\007", info.Title)
+	if system.IsLocal(c.Host) && info.ID != "" {
+		fmt.Printf("\033]2;%s\007", info.ID)
 	}
 
 	if bin == "ssh" {

--- a/internal/shell/builder.go
+++ b/internal/shell/builder.go
@@ -8,20 +8,18 @@ import (
 	"atelier-go/internal/system"
 )
 
-// SessionInfo holds the calculated session ID and window title.
+// SessionInfo holds the calculated session ID.
 type SessionInfo struct {
-	ID    string
-	Title string
+	ID string
 }
 
-// PrepareSessionInfo calculates the session ID and window title based on inputs.
+// PrepareSessionInfo calculates the session ID based on inputs.
 func PrepareSessionInfo(path, name, actionName string, isProject bool) SessionInfo {
 	if isProject {
 		safeName := strings.ReplaceAll(strings.ToLower(name), " ", "-")
 		safeActionName := strings.ReplaceAll(strings.ToLower(actionName), " ", "-")
 		return SessionInfo{
-			ID:    fmt.Sprintf("[%s:%s]", safeName, safeActionName),
-			Title: fmt.Sprintf("%s - %s", name, actionName),
+			ID: fmt.Sprintf("[%s:%s]", safeName, safeActionName),
 		}
 	}
 
@@ -29,8 +27,7 @@ func PrepareSessionInfo(path, name, actionName string, isProject bool) SessionIn
 	safeAction := strings.ReplaceAll(actionName, " ", "-")
 	id := fmt.Sprintf("[%s:%s]", safePath, safeAction)
 	return SessionInfo{
-		ID:    id,
-		Title: id,
+		ID: id,
 	}
 }
 
@@ -101,11 +98,11 @@ func BuildStartArgs(host, path string, info SessionInfo, actionCmd string) (stri
 		"-t", host,
 	}
 
-	if info.Title != "" {
-		// printf "\033]2;%s\007" "Title"
-		// We escape double quotes in the title
-		safeTitle := strings.ReplaceAll(info.Title, "\"", "\\\"")
-		args = append(args, "printf", fmt.Sprintf("\"\\033]2;%s\\007\"", safeTitle), "&&")
+	if info.ID != "" {
+		// printf "\033]2;%s\007" "ID"
+		// We escape double quotes in the ID
+		safeID := strings.ReplaceAll(info.ID, "\"", "\\\"")
+		args = append(args, "printf", fmt.Sprintf("\"\\033]2;%s\\007\"", safeID), "&&")
 	}
 
 	args = append(args,


### PR DESCRIPTION
This pull request refactors session window title handling by removing the `Title` field from the `SessionInfo` struct and standardizing the use of session `ID` for window titles throughout the codebase. The changes simplify session identification and ensure consistency when setting terminal window titles.

Session info refactoring:

* Removed the `Title` field from the `SessionInfo` struct and updated related comments and logic to only use the `ID` field. (`internal/shell/builder.go`)
* Updated the `PrepareSessionInfo` function to exclude the `Title` field and only set the session `ID`. (`internal/shell/builder.go`)

Window title standardization:

* Modified logic in `BuildStartArgs` to use `info.ID` instead of `info.Title` when setting the terminal window title, including escaping double quotes. (`internal/shell/builder.go`)
* Updated the `Client.Start` method to set the window title using `info.ID` rather than `info.Title`. (`internal/client/client.go`)