### PR TITLE
Usage and help updates

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -24,7 +24,24 @@ const (
 
 var clientCmd = &cobra.Command{
 	Use:   "client",
-	Short: "Connect to the Atelier daemon",
+	Short: "Connect to the server and manage sessions",
+	Long: `The client command connects to the running Atelier server.
+
+It presents an interactive list of:
+- Active 'shpool' sessions
+- Defined projects
+- Frequent directories (via zoxide)
+
+You can filter this list using flags. Selecting an item will either attach
+to an existing session or start a new one in that location.`,
+	Example: `  # Default: Show sessions, projects, and frequent paths
+  atelier-go client
+
+  # Show only active sessions
+  atelier-go client --sessions
+
+  # Show ALL directories (can be slow)
+  atelier-go client --all`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		system.LoadConfig("client")
 	},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,7 +10,22 @@ import (
 
 var rootCmd = &cobra.Command{
 	Use:   "atelier-go",
-	Short: "Atelier Go - Remote Development Daemon & Client",
+	Short: "Atelier Go - Remote Development Server & Client",
+	Long: `Atelier Go is a unified tool for managing remote development environments.
+
+It consists of two parts:
+1. A Server that runs on your development machine/host.
+2. A Client that you run to connect, manage, and attach to sessions.
+
+It integrates with 'shpool' for persistent sessions and 'zoxide' for smart path navigation.`,
+	Example: `  # Start the server in the background
+  atelier-go server start
+
+  # Connect to the server to select a session or project
+  atelier-go client
+
+  # Check server status
+  atelier-go server status`,
 }
 
 func Execute() {

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -36,7 +36,11 @@ func printStartupBanner(addr, token string) {
 
 var serverCmd = &cobra.Command{
 	Use:   "server",
-	Short: "Start the Atelier daemon",
+	Short: "Run the Atelier server (foreground)",
+	Long: `Starts the Atelier server process in the current terminal window.
+This is useful for debugging or running in a container.
+For normal usage, consider using 'server start' to run in the background.`,
+	Example: `  atelier-go server --port 9005`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		system.LoadConfig("server")
 	},
@@ -127,6 +131,10 @@ var serverCmd = &cobra.Command{
 var serverStartCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Start the server in the background",
+	Long: `Starts the Atelier server as a detached background process.
+It writes a PID file to ensure only one instance runs at a time.
+Use 'server stop' to shut it down.`,
+	Example: `  atelier-go server start`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Check if already running
 		pid, err := system.ReadPIDFile()
@@ -190,6 +198,9 @@ var serverStartCmd = &cobra.Command{
 var serverStopCmd = &cobra.Command{
 	Use:   "stop",
 	Short: "Stop the background server",
+	Long: `Stops the currently running background server instance
+identified by the PID file.`,
+	Example: `  atelier-go server stop`,
 	Run: func(cmd *cobra.Command, args []string) {
 		pid, err := system.ReadPIDFile()
 		if err != nil {
@@ -218,6 +229,10 @@ var serverStopCmd = &cobra.Command{
 var serverInstallCmd = &cobra.Command{
 	Use:   "install",
 	Short: "Install the server as a systemd user service",
+	Long: `Generates a systemd user service file and installs it.
+This allows the Atelier server to start automatically when you log in.
+Files are installed to ~/.local/share/systemd/user/.`,
+	Example: `  atelier-go server install`,
 	Run: func(cmd *cobra.Command, args []string) {
 		exe, err := os.Executable()
 		if err != nil {
@@ -301,6 +316,10 @@ WantedBy=default.target
 var serverTokenCmd = &cobra.Command{
 	Use:   "token",
 	Short: "Print the current authentication token",
+	Long: `Retrieves and prints the current authentication token.
+This is useful if you need to manually configure a client or script
+authentication.`,
+	Example: `  atelier-go server token`,
 	Run: func(cmd *cobra.Command, args []string) {
 		tokenPath, err := auth.GetDefaultTokenPath()
 		if err != nil {
@@ -320,7 +339,10 @@ var serverTokenCmd = &cobra.Command{
 
 var serverStatusCmd = &cobra.Command{
 	Use:   "status",
-	Short: "Check the status of the Atelier daemon",
+	Short: "Check the status of the Atelier server",
+	Long: `Sends a health check request to the running server.
+Verifies that the server process is running and responding to HTTP requests.`,
+	Example: `  atelier-go server status`,
 	Run: func(cmd *cobra.Command, args []string) {
 		host := viper.GetString("host")
 		if host == "" || host == "0.0.0.0" {


### PR DESCRIPTION
This pull request improves the user experience and documentation for the `atelier-go` CLI by expanding and clarifying the help text, descriptions, and usage examples for both server and client commands. The changes make it easier for users to understand the purpose and usage of each command, and provide clear instructions for common workflows.

**Command documentation and usability improvements:**

* Expanded the `client` command's `Short`, `Long`, and `Example` fields to better explain its functionality, including session management and directory navigation, and added usage examples.
* Enhanced the root command (`atelier-go`) with a more detailed description, outlining the server/client architecture, integration with `shpool` and `zoxide`, and added usage examples for starting the server, connecting the client, and checking status.

**Server command documentation enhancements:**

* Improved the `server` command's descriptions and examples, clarifying its use for foreground operation and debugging, and recommending `server start` for background use.
* Added detailed `Long` descriptions and usage examples to the `server start`, `server stop`, `server install`, `server token`, and `server status` subcommands, making their purposes and workflows clearer for users. [[1]](diffhunk://#diff-ee2560d627cd77f1563972217a33ac39a4bf56fbf30d7f560fbb4199b9f70197R134-R137) [[2]](diffhunk://#diff-ee2560d627cd77f1563972217a33ac39a4bf56fbf30d7f560fbb4199b9f70197R201-R203) [[3]](diffhunk://#diff-ee2560d627cd77f1563972217a33ac39a4bf56fbf30d7f560fbb4199b9f70197R232-R235) [[4]](diffhunk://#diff-ee2560d627cd77f1563972217a33ac39a4bf56fbf30d7f560fbb4199b9f70197R319-R322) [[5]](diffhunk://#diff-ee2560d627cd77f1563972217a33ac39a4bf56fbf30d7f560fbb4199b9f70197L323-R345)
