### PR TITLE
Version flag

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,6 +10,9 @@ before:
 builds:
   - env:
       - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+      - -X atelier-go/cmd.version={{.Version}}
     goos:
       - linux
       - darwin

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@
 # Binary output path
 BINARY_NAME=bin/atelier-go
 
+# Version info for local builds
+VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+
 # Go parameters
 GOCMD=go
 GOBUILD=$(GOCMD) build
@@ -10,7 +13,7 @@ GOCLEAN=$(GOCMD) clean
 GOTEST=$(GOCMD) test
 
 # Build flags
-LDFLAGS=-ldflags "-s -w"
+LDFLAGS=-ldflags "-s -w -X atelier-go/cmd.version=$(VERSION)"
 
 .PHONY: all build clean test run help
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,9 +8,12 @@ import (
 	"github.com/spf13/viper"
 )
 
+var version = "dev"
+
 var rootCmd = &cobra.Command{
-	Use:   "atelier-go",
-	Short: "Atelier Go - Remote Development Server & Client",
+	Use:     "atelier-go",
+	Version: version,
+	Short:   "Atelier Go - Remote Development Server & Client",
 	Long: `Atelier Go is a unified tool for managing remote development environments.
 
 It consists of two parts:
@@ -37,6 +40,9 @@ func Execute() {
 
 func init() {
 	cobra.OnInitialize(initConfig)
+
+	// Add version flag with shorthand -v
+	rootCmd.Flags().BoolP("version", "v", false, "Print the version number")
 
 	// Global flags (optional, but good practice to map them)
 	rootCmd.PersistentFlags().String("host", "", "Host to connect to (client) or bind to (server)")


### PR DESCRIPTION
This pull request introduces versioning support to the build and CLI for the `atelier-go` project. The changes ensure that version information is embedded in the binary during both release and local builds, and that users can easily access the version from the command line.

**Build and Versioning Improvements:**

* Added `ldflags` to `.goreleaser.yaml` to embed version info from the release process into the binary (`atelier-go/cmd.version={{.Version}}`).
* Updated the `Makefile` to set the `VERSION` variable using `git describe` and pass it to the build via `ldflags`, ensuring local builds also have version info embedded.

**Command-Line Interface Enhancements:**

* Declared a `version` variable in `cmd/root.go`, defaulting to `"dev"`, and set it as the `Version` field for the CLI root command.
* Added a `--version` (shorthand `-v`) flag to the CLI, allowing users to print the current version directly from the command line.