### PR TITLE
Restart server

### DIFF
--- a/internal/system/daemon.go
+++ b/internal/system/daemon.go
@@ -1,10 +1,13 @@
 package system
 
 import (
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"syscall"
+	"time"
 )
 
 // GetPIDFilePath returns the path to the PID file.
@@ -53,4 +56,76 @@ func IsProcessRunning(pid int) bool {
 	// Sending signal 0 is a way to check if the process exists without killing it.
 	err = process.Signal(syscall.Signal(0))
 	return err == nil
+}
+
+// StopDaemon stops the background process identified by the PID file.
+// It returns true if a process was stopped, false if no process was running.
+func StopDaemon() (bool, error) {
+	pid, err := ReadPIDFile()
+	if err != nil {
+		return false, nil // No PID file, nothing to stop
+	}
+
+	if !IsProcessRunning(pid) {
+		RemovePIDFile()
+		return false, nil // Process not running
+	}
+
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		RemovePIDFile()
+		return false, nil // Process not found
+	}
+
+	if err := proc.Kill(); err != nil {
+		// If we can't kill it, maybe it's already dead or we don't have permission.
+		// Check if it's still running.
+		if IsProcessRunning(pid) {
+			return false, fmt.Errorf("failed to kill process %d: %w", pid, err)
+		}
+	}
+
+	// Wait briefly for process to terminate
+	time.Sleep(500 * time.Millisecond)
+	RemovePIDFile()
+	return true, nil
+}
+
+// StartDetached starts the current executable with the given arguments as a detached process.
+// It writes the PID file and returns the new PID.
+func StartDetached(args ...string) (int, error) {
+	// Check if already running
+	pid, err := ReadPIDFile()
+	if err == nil {
+		if IsProcessRunning(pid) {
+			return pid, fmt.Errorf("process already running (PID: %d)", pid)
+		}
+		// Stale PID file
+		RemovePIDFile()
+	}
+
+	// Find the executable
+	exe, err := os.Executable()
+	if err != nil {
+		return 0, fmt.Errorf("failed to determine executable path: %w", err)
+	}
+
+	// Start the process detached
+	cmd := exec.Command(exe, args...)
+
+	// Detach I/O
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	cmd.Stdin = nil
+
+	if err := cmd.Start(); err != nil {
+		return 0, fmt.Errorf("failed to start process: %w", err)
+	}
+
+	if err := WritePIDFile(cmd.Process.Pid); err != nil {
+		cmd.Process.Kill()
+		return 0, fmt.Errorf("failed to write PID file: %w", err)
+	}
+
+	return cmd.Process.Pid, nil
 }


### PR DESCRIPTION
This pull request refactors the server process management logic to centralize and simplify how the server is started, stopped, and restarted. The main improvements include extracting process management into reusable functions, introducing a `restart` command, and improving handling for both systemd-managed and non-systemd-managed environments.

**Process management refactor:**

* Added `StartDetached` and `StopDaemon` utility functions in `internal/system/daemon.go` to encapsulate starting and stopping the server as a background process, including PID file management and process checks. This reduces code duplication and improves reliability.
* Updated the `server start` and `server stop` command implementations in `cmd/server.go` to use the new `StartDetached` and `StopDaemon` functions, simplifying the logic and ensuring consistent process handling. [[1]](diffhunk://#diff-ee2560d627cd77f1563972217a33ac39a4bf56fbf30d7f560fbb4199b9f70197L139-R145) [[2]](diffhunk://#diff-ee2560d627cd77f1563972217a33ac39a4bf56fbf30d7f560fbb4199b9f70197L205-R182)

**New server restart functionality:**

* Added a new `server restart` command in `cmd/server.go` that restarts the server process. If the server is managed by systemd, it uses `systemctl`; otherwise, it uses the new process management utilities to stop and start the background process.

**Systemd integration:**

* Added logic to detect if the server is managed by systemd (`isSystemdServiceActive`) and to handle restart operations appropriately, improving compatibility with different deployment environments.

**Other improvements:**

* Minor import additions in `internal/system/daemon.go` to support new functionality.