### PR TITLE
Terminal window titles.

### DIFF
--- a/internal/sessions/sessions.go
+++ b/internal/sessions/sessions.go
@@ -30,6 +30,8 @@ func NewManager() *Manager {
 
 // Attach connects to an existing zmx session or creates a new one with the given name.
 func (m *Manager) Attach(name string, dir string, args ...string) error {
+	utils.SetTerminalTitle(name)
+
 	cmdArgs := []string{"attach", name}
 	if len(args) > 0 {
 		cmdArgs = append(cmdArgs, args...)

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -2,6 +2,7 @@
 package utils
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -49,6 +50,11 @@ func ExpandPath(path string) (string, error) {
 	}
 
 	return expanded, nil
+}
+
+// SetTerminalTitle updates the terminal window title using ANSI escape sequences.
+func SetTerminalTitle(title string) {
+	fmt.Printf("\033]0;%s\007", title)
 }
 
 // GetHostname returns the effective hostname for configuration purposes.


### PR DESCRIPTION
This pull request introduces a small enhancement to the session management experience by updating the terminal window title when attaching to a session. It also adds a utility function to handle this update using ANSI escape sequences.

Session management improvements:
* The `Manager.Attach` method now sets the terminal window title to the session name when attaching to a session, improving user experience by providing clear context in the terminal window.

Utility function addition:
* Added a new utility function `SetTerminalTitle` in `utils.go` to update the terminal window title using ANSI escape sequences.
* Updated imports in `utils.go` to include `fmt` for terminal title formatting.